### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "7c75c113-50c5-4959-bbaf-ef7d9a383896",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing J locally",
+      "blurb": "Learn how to install J locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "38a556a2-abbb-4a54-8ec2-4d247d985242",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn J",
+      "blurb": "An overview of how to get started from scratch with J"
+    },
+    {
+      "uuid": "9bc3b733-1790-4b39-ab29-1fb0a03817e1",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the J track",
+      "blurb": "Learn how to test your J exercises on Exercism"
+    },
+    {
+      "uuid": "11c1c3aa-383e-4fee-8e30-4fb01581a722",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful J resources",
+      "blurb": "A collection of useful resources to help you master J"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
