### PR TITLE
🤖 Sync exercise files keys based on file path patterns

### DIFF
--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "difference-of-squares.ijs"
+    ],
+    "test": [
+      "test.ijs"
+    ],
+    "example": [
+      "example.ijs"
+    ]
   },
   "source": "Problem 6 at Project Euler",
   "source_url": "http://projecteuler.net/problem=6"

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Calculate the Hamming difference between two DNA strands.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "hamming.ijs"
+    ],
+    "test": [
+      "test.ijs"
+    ],
+    "example": [
+      "example.ijs"
+    ]
   },
   "source": "The Calculating Point Mutations problem at Rosalind",
   "source_url": "http://rosalind.info/problems/hamm/"

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "hello-world.ijs"
+    ],
+    "test": [
+      "test.ijs"
+    ],
+    "example": [
+      "example.ijs"
+    ]
   },
   "source": "This is an exercise to introduce users to using Exercism",
   "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "nucleotide-count.ijs"
+    ],
+    "test": [
+      "test.ijs"
+    ],
+    "example": [
+      "example.ijs"
+    ]
   },
   "source": "The Calculating DNA Nucleotides_problem at Rosalind",
   "source_url": "http://rosalind.info/problems/dna/"

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Compute Pascal's triangle up to a given number of rows.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "pascals-triangle.ijs"
+    ],
+    "test": [
+      "test.ijs"
+    ],
+    "example": [
+      "example.ijs"
+    ]
   },
   "source": "Pascal's Triangle at Wolfram Math World",
   "source_url": "http://mathworld.wolfram.com/PascalsTriangle.html"

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "rna-transcription.ijs"
+    ],
+    "test": [
+      "test.ijs"
+    ],
+    "example": [
+      "example.ijs"
+    ]
   },
   "source": "Hyperphysics",
   "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html"

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a number, find the sum of all the multiples of particular numbers up to but not including that number.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "sum-of-multiples.ijs"
+    ],
+    "test": [
+      "test.ijs"
+    ],
+    "example": [
+      "example.ijs"
+    ]
   },
   "source": "A variation on Problem 1 at Project Euler",
   "source_url": "http://projecteuler.net/problem=1"


### PR DESCRIPTION
To help tracks define the files in the exercise's `.meta/config.json` file, we've added support for defining these file patterns in the track's `config.json` file. See [this PR](https://github.com/exercism/docs/pull/58).

This PR updates the file paths defined in the `files` property of each exercise's `.meta/config.json` file according to the file patterns defined in the track's `config.json` file.

We only update a file path in the `.meta/config.json` file if:

- The file path pattern is a non-empty array in the `config.json` file
- The file path pattern is either not set or an empty array in the `.meta/config.json` file

This means that exercises that had already defined files in the `.meta/config.json` won't be touched in this PR.

Note that this PR is just an easy way for tracks to populate the files in the `.meta/config.json` files. Tracks are completely free to add/change/remove the files in their `.meta/config.json` files.

In the future, we'll update `configlet` to include this functionality. If you'd like me to re-run the script because changes have been made, feel free to ping me on Slack (@erikschierboom).

## Tracking

https://github.com/exercism/v3-launch/issues/20

