### PR TITLE
GitHub Actions Testing Files and Bug Fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+# This workflow will do a clean install of the dependencies and run tests across different versions
+#
+# Replace <track> with the track name
+# Replace <image-name> with an image to run the jobs on
+# Replace <action to setup tooling> with a github action to setup tooling on the image
+# Replace <install dependencies> with a cli command to install the dependencies
+#
+# Find Github Actions to setup tooling here:
+# - https://github.com/actions/?q=setup&type=&language=
+# - https://github.com/actions/starter-workflows/tree/main/ci
+# - https://github.com/marketplace?type=actions&query=setup
+#
+# Requires scripts:
+# - bin/test
+
+name: <track> / Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  ci:
+    runs-on: <image-name>
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+
+      - name: Use <setup tooling>
+        uses: <action to setup tooling>
+
+      - name: Install project dependencies
+        run: <install dependencies>
+
+      - name: Verify all exercises
+        run: bin/verify-exercises

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,27 +13,33 @@
 # Requires scripts:
 # - bin/test
 
-name: <track> / Test
+name: J / Test
 
 on:
   push:
     branches: [main]
-  pull_request:
+  pull_request: 
   workflow_dispatch:
 
 jobs:
-  ci:
-    runs-on: <image-name>
+  test:
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
 
-      - name: Use <setup tooling>
-        uses: <action to setup tooling>
-
       - name: Install project dependencies
-        run: <install dependencies>
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends wget ca-certificates
+
+      - name: Install J
+        run: |
+          wget https://www.jsoftware.com/download/j9.5/install/j9.5_linux64.tar.gz
+          tar -xvf j9.5_linux64.tar.gz
+          mv j9.5 /opt/j9.5
+          rm -rf j9.5_linux64.tar.gz
 
       - name: Verify all exercises
-        run: bin/verify-exercises
+        run: ./bin/verify-exercises.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,4 +42,4 @@ jobs:
           rm -rf j9.5_linux64.tar.gz
 
       - name: Verify all exercises
-        run: ./bin/verify-exercises.sh
+        run: bin/verify-exercises.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,9 @@ name: J / Test
 
 on:
   push:
-    branches: [main]
+    branches: [main; add-test-workflows]
   pull_request: 
-  workflow_dispatch:
+  workflow_dispatch: 
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,9 @@ name: J / Test
 
 on:
   push:
-    branches: [main; add-test-workflows]
+    branches: [main]
   pull_request: 
-  workflow_dispatch: 
+  workflow_dispatch:
 
 jobs:
   test:

--- a/bin/test_exercise.ijs
+++ b/bin/test_exercise.ijs
@@ -1,0 +1,39 @@
+#! /opt/j9.5/bin/jconsole
+
+try_error=: 3 : 0
+  for_i. y do. 
+    test_name      =. > i
+    error_expected =. ( 5 }. test_name , '_expect')~
+    try.
+      0!:100 fputs test_name , (quote'')
+    catch.
+      errname=. > (<: 13!:11'') { 9!:8''
+      if. errname -.@-: error_expected do.
+        0 return.
+      end.
+    end.
+  end.
+  1 return.
+)
+
+main=: monad define
+  exercise_dir=. _1 { ARGV
+  1!:44 >exercise_dir
+  tests=. ('[a-zA-Z0-9[-]*]*[.]ijs'; '.meta/example.ijs') rxrplc 1!:1 <'test.ijs'     NB. Replace load directive for the tests
+  0!:0 tests                                                                          NB. load to put the tests in `nl`
+  before_all ''                                                                       NB. tests verbs depends on values setted at `before_all`
+  tests=. 'test_' nl 3                                                                NB. get defined tests from `nl`
+  errors=. ('test_'&,)each (_7&}.)each '_expect*' nl 0
+
+  if. 0-.@-:#errors do.
+    'expect_value expect_error'=. (tests e. errors) </. tests
+    test_values=. 0!:3 fputs (,&(quote''))every expect_value
+    test_errors=. try_error expect_error
+    exit -.(test_values *. test_errors)
+  else.
+    exit -. 0!:3 fputs (,&(quote''))every tests
+  end.
+
+)
+
+main''

--- a/bin/verify-exercises.sh
+++ b/bin/verify-exercises.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Synopsis:
+# Test the track's exercises.
+# 
+# At a minimum, this file must check if the example/exemplar solution of each 
+# Practice/Concept Exercise passes the exercise's tests.
+#
+# To check this, you usually have to (temporarily) replace the exercise's solution files
+# with its exemplar/example files.
+#
+# If your track uses skipped tests, make sure to (temporarily) enable these tests
+# before running the tests.
+#
+# The path to the solution/example/exemplar files can be found in the exercise's
+# .meta/config.json file, or possibly inferred from the exercise's directory name.
+
+# Example:
+# ./bin/test
+
+# Verify the Concept Exercises
+for concept_exercise_dir in ./exercises/concept/*/; do
+    if [ -d $concept_exercise_dir ]; then
+        echo "Checking $(basename "${concept_exercise_dir}") exercise..."
+        # TODO: run command to verify that the exemplar solution passes the tests
+    fi
+done
+
+# Verify the Practice Exercises
+for practice_exercise_dir in ./exercises/practice/*/; do
+    if [ -d $practice_exercise_dir ]; then
+        echo "Checking $(basename "${practice_exercise_dir}") exercise..."
+        # TODO: run command to verify that the example solution passes the tests
+    fi
+done

--- a/bin/verify-exercises.sh
+++ b/bin/verify-exercises.sh
@@ -21,20 +21,20 @@
 exit_code=0
 
 # Verify the Concept Exercises
-for concept_exercise_dir in ./exercises/concept/*/; do
-    if [ -d $concept_exercise_dir ]; then
-        echo "Checking $(basename "${concept_exercise_dir}") exercise..."
-        # TODO: run command to verify that the exemplar solution passes the tests
-    fi
-done
+# for concept_exercise_dir in ./exercises/concept/*/; do
+#     if [ -d $concept_exercise_dir ]; then
+#         echo "Checking $(basename "${concept_exercise_dir}") exercise..."
+#         # TODO: run command to verify that the exemplar solution passes the tests
+#     fi
+# done
 
 # Verify the Practice Exercises
 for practice_exercise_dir in ./exercises/practice/*/; do
     if [ -d $practice_exercise_dir ]; then
         echo "Checking $(basename "${practice_exercise_dir}") exercise..."
-        res= $(/opt/j9.5/bin/jconsole bin/test_exercise.ijs "$practice_exercise_dir/")
+        res=$(/opt/j9.5/bin/jconsole bin/test_exercise.ijs "$practice_exercise_dir/")
         if [ $? -ne 0 ]; then 
-            echo "Error in $("${practice_exercise_dir}")"
+            echo "Error in ${practice_exercise_dir}"
             ((exit_code++))
         fi
     fi

--- a/bin/verify-exercises.sh
+++ b/bin/verify-exercises.sh
@@ -18,6 +18,8 @@
 # Example:
 # ./bin/test
 
+exit_code=0
+
 # Verify the Concept Exercises
 for concept_exercise_dir in ./exercises/concept/*/; do
     if [ -d $concept_exercise_dir ]; then
@@ -30,6 +32,12 @@ done
 for practice_exercise_dir in ./exercises/practice/*/; do
     if [ -d $practice_exercise_dir ]; then
         echo "Checking $(basename "${practice_exercise_dir}") exercise..."
-        # TODO: run command to verify that the example solution passes the tests
+        res= $(/opt/j9.5/bin/jconsole bin/test_exercise.ijs "$practice_exercise_dir/")
+        if [ $? -ne 0 ]; then 
+            echo "Error in $("${practice_exercise_dir}")"
+            ((exit_code++))
+        fi
     fi
 done
+
+exit $exit_code

--- a/exercises/practice/all-your-base/test.ijs
+++ b/exercises/practice/all-your-base/test.ijs
@@ -13,11 +13,12 @@ test_all_your_base_test_01  =: monad define
   Description@.1 ('single bit one to decimal')
   Order@.1 (1)
 
-  NB. inputBase=. 2
-  NB. digits=. 1
-  NB. outputBase=. 10
-  NB. expected=. 1
-  assert 1 = rebase 2; 1; 10
+  input_base  =. 2
+  digits      =. 1$1
+  output_base =. 10
+  expected    =. 1$1
+
+  assert expected -: rebase input_base; digits; output_base
 )
 
 all_your_base_test_02_ignore=: 1 NB. Change this value to 0 to run this test
@@ -25,11 +26,11 @@ test_all_your_base_test_02  =: monad define
   Description@.1 ('binary to single decimal')
   Order@.1 (2)
 
-  NB. inputBase=. 2
-  NB. digits=. 1 0 1
-  NB. outputBase=. 10
-  NB. expected=. 5
-  assert 5 = rebase 2; 1 0 1 ;10
+  input_base  =. 2
+  digits      =. 1 0 1
+  output_base =. 10
+  expected    =. 1$5
+  assert expected -: rebase input_base; digits; output_base
 )
 
 all_your_base_test_03_ignore=: 1 NB. Change this value to 0 to run this test
@@ -37,11 +38,11 @@ test_all_your_base_test_03  =: monad define
   Description@.1 ('single decimal to binary')
   Order@.1 (3)
 
-  NB. inputBase=. 10
-  NB. digits=. 5
-  NB. outputBase=. 2
-  NB. expected=. 1 0 1
-  assert 1 0 1 = rebase 10; 5; 2
+  input_base  =. 10
+  digits      =. 1$5
+  output_base =. 2
+  expected    =. 1 0 1
+  assert expected -: rebase input_base; digits; output_base
 )
 
 all_your_base_test_04_ignore=: 1 NB. Change this value to 0 to run this test
@@ -49,11 +50,11 @@ test_all_your_base_test_04  =: monad define
   Description@.1 ('binary to multiple decimal')
   Order@.1 (4)
 
-  NB. inputBase=. 2
-  NB. digits=. 1 0 1 0 1 0
-  NB. outputBase=. 10
-  NB. expected=. 4 2
-  assert 4 2 = rebase 2; 1 0 1 0 1 0; 10
+  input_base  =. 2
+  digits      =. 1 0 1 0 1 0
+  output_base =. 10
+  expected    =. 4 2
+  assert expected -: rebase input_base; digits; output_base
 )
 
 all_your_base_test_05_ignore=: 1 NB. Change this value to 0 to run this test
@@ -61,11 +62,11 @@ test_all_your_base_test_05  =: monad define
   Description@.1 ('decimal to binary')
   Order@.1 (5)
 
-  NB. inputBase=. 10
-  NB. digits=. 4 2
-  NB. outputBase=. 2
-  NB. expected=. 1 0 1 0 1 0
-  assert 1 0 1 0 1 0 = rebase 10; 4 2; 2
+  input_base  =. 10
+  digits      =. 4 2
+  output_base =. 2
+  expected    =. 1 0 1 0 1 0
+  assert expected -: rebase input_base; digits; output_base
 )
 
 all_your_base_test_06_ignore=: 1 NB. Change this value to 0 to run this test
@@ -73,11 +74,11 @@ test_all_your_base_test_06  =: monad define
   Description@.1 ('trinary to hexadecimal')
   Order@.1 (6)
 
-  NB. inputBase=. 3
-  NB. digits=. 1 1 2 0
-  NB. outputBase=. 16
-  NB. expected=. 2 10
-  assert 2 10 = rebase 3; 1 1 2 0; 16
+  input_base  =. 3
+  digits      =. 1 1 2 0
+  output_base =. 16
+  expected    =. 2 10
+  assert expected -: rebase input_base; digits; output_base
 )
 
 all_your_base_test_07_ignore=: 1 NB. Change this value to 0 to run this test
@@ -85,11 +86,11 @@ test_all_your_base_test_07  =: monad define
   Description@.1 ('hexadecimal to trinary')
   Order@.1 (7)
 
-  NB. inputBase=. 16
-  NB. digits=. 2 10
-  NB. outputBase=. 3
-  NB. expected=. 1 1 2 0
-  assert 1 1 2 0 = rebase 16; 2 10; 3
+  input_base  =. 16
+  digits      =. 2 10
+  output_base =. 3
+  expected    =. 1 1 2 0
+  assert expected -: rebase input_base; digits; output_base
 )
 
 all_your_base_test_08_ignore=: 1 NB. Change this value to 0 to run this test
@@ -97,11 +98,11 @@ test_all_your_base_test_08  =: monad define
   Description@.1 ('15-bit integer')
   Order@.1 (8)
 
-  NB. inputBase=. 97
-  NB. digits=. 3 46 60
-  NB. outputBase=. 73
-  NB. expected=. 6 10 45
-  assert 6 10 45 = rebase 97; 3 46 60; 73
+  input_base  =. 97
+  digits      =. 3 46 60
+  output_base =. 73
+  expected    =. 6 10 45
+  assert expected -: rebase input_base; digits; output_base
 )
 
 all_your_base_test_09_ignore=: 1 NB. Change this value to 0 to run this test
@@ -109,11 +110,11 @@ test_all_your_base_test_09  =: monad define
   Description@.1 ('empty list')
   Order@.1 (9)
 
-  NB. inputBase=. 2
-  NB. digits=. ''
-  NB. outputBase=. 10
-  NB. expected=. 0
-  assert 0 = rebase 2; '';10
+  input_base  =. 2
+  digits      =. ''
+  output_base =. 10
+  expected    =. 1$0
+  assert expected -: rebase input_base; digits; output_base
 )
 
 all_your_base_test_10_ignore=: 1 NB. Change this value to 0 to run this test
@@ -121,11 +122,11 @@ test_all_your_base_test_10  =: monad define
   Description@.1 ('single zero')
   Order@.1 (10)
 
-  NB. inputBase=. 10
-  NB. digits=. 0
-  NB. outputBase=. 2
-  NB. expected=. 0
-  assert 0 = rebase 10; (0); 2
+  input_base  =. 10
+  digits      =. 1$0
+  output_base =. 2
+  expected    =. 1$0
+  assert expected -: rebase input_base; digits; output_base
 )
 
 all_your_base_test_11_ignore=: 1 NB. Change this value to 0 to run this test
@@ -133,11 +134,11 @@ test_all_your_base_test_11  =: monad define
   Description@.1 ('multiple zeros')
   Order@.1 (11)
 
-  NB. inputBase=. 10
-  NB. digits=. 0 0 0
-  NB. outputBase=. 2
-  NB. expected=. 0
-  assert 0 = rebase 10; 0 0 0; 2
+  input_base  =. 10
+  digits      =. 0 0 0
+  output_base =. 2
+  expected    =. 1$0
+  assert expected -: rebase input_base; digits; output_base
 )
 
 all_your_base_test_12_ignore=: 1 NB. Change this value to 0 to run this test
@@ -145,11 +146,11 @@ test_all_your_base_test_12  =: monad define
   Description@.1 ('leading zeros')
   Order@.1 (12)
 
-  NB. inputBase=. 7
-  NB. digits=. 0 6 0
-  NB. outputBase=. 10
-  NB. expected=. 4 2
-  assert 4 2 = rebase 7; 0 6 0; 10
+  input_base  =. 7
+  digits      =. 0 6 0
+  output_base =. 10
+  expected    =. 4 2
+  assert expected -: rebase input_base; digits; output_base
 )
 
 
@@ -161,11 +162,11 @@ test_all_your_base_test_13  =: monad define
   Description@.1 ('input base is one')
   Order@.1 (13)
 
-  NB. inputBase=. 1
-  NB. digits=. (0)
-  NB. outputBase=. 10
-  NB. expected=. ''    NB. error=. 'input base must be >= 2'
-  assert '' -: rebase 1; 1; 10
+  input_base  =. 1
+  digits      =. 1$0
+  output_base =. 10
+  expected    =. ''    NB. error=. 'input base must be >= 2'
+  assert expected -: rebase input_base; digits; output_base
 )
 
 all_your_base_test_14_ignore=: 1 NB. Change this value to 0 to run this test
@@ -173,11 +174,11 @@ test_all_your_base_test_14  =: monad define
   Description@.1 ('input base is zero')
   Order@.1 (14)
 
-  NB. inputBase=. 0
-  NB. digits=. ''
-  NB. outputBase=. 10
-  NB. expected=.  ''   NB. error=. 'input base must be >= 2'
-  assert '' -: rebase 0; '';10
+  input_base  =. 0
+  digits      =. ''
+  output_base =. 10
+  expected    =.  ''   NB. error=. 'input base must be >= 2'
+  assert expected -: rebase input_base; digits; output_base
 )
 
 all_your_base_test_15_ignore=: 1 NB. Change this value to 0 to run this test
@@ -185,11 +186,11 @@ test_all_your_base_test_15  =: monad define
   Description@.1 ('input base is negative')
   Order@.1 (15)
 
-  NB. inputBase=. _2
-  NB. digits=. 1
-  NB. outputBase=. 10
-  NB. expected=.  ''   NB. error=. 'input base must be >= 2'
-  assert '' -: rebase _2; 1; 10
+  input_base  =. _2
+  digits      =. 1$1
+  output_base =. 10
+  expected    =.  ''   NB. error=. 'input base must be >= 2'
+  assert expected -: rebase input_base; digits; output_base
 )
 
 all_your_base_test_16_ignore=: 1 NB. Change this value to 0 to run this test
@@ -197,11 +198,11 @@ test_all_your_base_test_16  =: monad define
   Description@.1 ('negative digit')
   Order@.1 (16)
 
-  NB. inputBase=. 2
-  NB. digits=. 1 _1 1 0 1 0
-  NB. outputBase=. 10
-  NB. expected=.  ''   NB. error=. 'all digits must satisfy 0 <= d < input base'
-  assert '' -: rebase 2; 1 _1 1 0 1 0; 10
+  input_base  =. 2
+  digits      =. 1 _1 1 0 1 0
+  output_base =. 10
+  expected    =.  ''   NB. error=. 'all digits must satisfy 0 <= d < input base'
+  assert expected -: rebase input_base; digits; output_base
 )
 
 all_your_base_test_17_ignore=: 1 NB. Change this value to 0 to run this test
@@ -209,11 +210,11 @@ test_all_your_base_test_17  =: monad define
   Description@.1 ('invalid positive digit')
   Order@.1 (17)
 
-  NB. inputBase=. 2
-  NB. digits=. 1 2 1 0 1 0
-  NB. outputBase=. 10
-  NB. expected=.  ''   NB. error=. 'all digits must satisfy 0 <= d < input base'
-  assert '' -: rebase 2; 1 2 1 0 1 0; 10
+  input_base  =. 2
+  digits      =. 1 2 1 0 1 0
+  output_base =. 10
+  expected    =.  ''   NB. error=. 'all digits must satisfy 0 <= d < input base'
+  assert expected -: rebase input_base; digits; output_base
 )
 
 all_your_base_test_18_ignore=: 1 NB. Change this value to 0 to run this test
@@ -221,11 +222,11 @@ test_all_your_base_test_18  =: monad define
   Description@.1 ('output base is one')
   Order@.1 (18)
 
-  NB. inputBase=. 2
-  NB. digits=. 1 0 1 0 1 0
-  NB. outputBase=. 1
-  NB. expected=.  ''   NB. error=. 'output base must be >= 2'
-  assert '' -: rebase 2; 1 0 1 0 1 0; 1
+  input_base  =. 2
+  digits      =. 1 0 1 0 1 0
+  output_base =. 1
+  expected    =.  ''   NB. error=. 'output base must be >= 2'
+  assert expected -: rebase input_base; digits; output_base
 )
 
 all_your_base_test_19_ignore=: 1 NB. Change this value to 0 to run this test
@@ -233,11 +234,11 @@ test_all_your_base_test_19  =: monad define
   Description@.1 ('output base is zero')
   Order@.1 (19)
 
-  NB. inputBase=. 10
-  NB. digits=. 7
-  NB. outputBase=. 0
-  NB. expected=.  ''   NB. error=. 'output base must be >= 2'
-  assert '' -: rebase 10; 7; 0
+  input_base  =. 10
+  digits      =. 1$7
+  output_base =. 0
+  expected    =.  ''   NB. error=. 'output base must be >= 2'
+  assert expected -: rebase input_base; digits; output_base
 )
 
 all_your_base_test_20_ignore=: 1 NB. Change this value to 0 to run this test
@@ -245,11 +246,11 @@ test_all_your_base_test_20  =: monad define
   Description@.1 ('output base is negative')
   Order@.1 (20)
 
-  NB. inputBase=. 2
-  NB. digits=. 1
-  NB. outputBase=. _7
-  NB. expected=.  ''   NB. error=. 'output base must be >= 2'
-  assert '' -: rebase 2; 1; _7
+  input_base  =. 2
+  digits      =. 1$1
+  output_base =. _7
+  expected    =.  ''   NB. error=. 'output base must be >= 2'
+  assert expected -: rebase input_base; digits; output_base
 )
 
 all_your_base_test_21_ignore=: 1 NB. Change this value to 0 to run this test
@@ -257,9 +258,9 @@ test_all_your_base_test_21  =: monad define
   Description@.1 ('both bases are negative')
   Order@.1 (21)
 
-  NB. inputBase=. _2
-  NB. digits=. 1
-  NB. outputBase=. _7
-  NB. expected=.  ''   NB. error=. 'input base must be >= 2'
-  assert '' -: rebase _2; 1; _7
+  input_base  =. _2
+  digits      =. 1$1
+  output_base =. _7
+  expected    =.  ''   NB. error=. 'input base must be >= 2'
+  assert expected -: rebase input_base; digits; output_base
 )

--- a/exercises/practice/anagram/test.ijs
+++ b/exercises/practice/anagram/test.ijs
@@ -48,7 +48,7 @@ test_anagram_test_04  =: monad define
 
   subject    =. 'listen'
   candidates =. 'enlists' ; 'google' ; 'inlets' ; 'banana'
-  expected   =. 1 $ <'inlets'
+  expected   =. ,<'inlets'
   assert expected -: subject findAnagrams candidates
 )
 
@@ -80,7 +80,7 @@ test_anagram_test_07  =: monad define
   Order@.1 (7)
 
   subject    =. 'mass'
-  candidates =. 1 $ <'last'
+  candidates =. ,<'last'
   expected   =. ''
   assert expected -: subject findAnagrams candidates
 )
@@ -92,7 +92,7 @@ test_anagram_test_08  =: monad define
 
   subject    =. 'Orchestra'
   candidates =. 'cashregister' ; 'Carthorse' ; 'radishes'
-  expected   =.  1 $ <'Carthorse'
+  expected   =.  ,<'Carthorse'
   assert expected -: subject findAnagrams candidates
 )
 
@@ -103,7 +103,7 @@ test_anagram_test_09  =: monad define
 
   subject    =. 'Orchestra'
   candidates =. 'cashregister' ; 'carthorse' ; 'radishes'
-  expected   =.  1 $ <'carthorse'
+  expected   =.  ,<'carthorse'
   assert expected -: subject findAnagrams candidates
 )
 
@@ -114,7 +114,7 @@ test_anagram_test_10  =: monad define
 
   subject    =. 'orchestra'
   candidates =. 'cashregister' ; 'Carthorse' ; 'radishes'
-  expected   =.  1 $ <'Carthorse'
+  expected   =.  ,<'Carthorse'
   assert expected -: subject findAnagrams candidates
 )
 
@@ -124,7 +124,7 @@ test_anagram_test_11  =: monad define
   Order@.1 (11)
 
   subject    =. 'go'
-  candidates =. <'goGoGO'
+  candidates =. ,<'goGoGO'
   expected   =. ''
   assert expected -: subject findAnagrams candidates
 )
@@ -135,7 +135,7 @@ test_anagram_test_12  =: monad define
   Order@.1 (12)
 
   subject    =. 'tapper'
-  candidates =. 1 $ <'patter'
+  candidates =. ,<'patter'
   expected   =. ''
   assert expected -: subject findAnagrams candidates
 )
@@ -146,7 +146,7 @@ test_anagram_test_13  =: monad define
   Order@.1 (13)
 
   subject    =. 'BANANA'
-  candidates =. 1 $ <'banana'
+  candidates =. ,<'banana'
   expected   =. ''
   assert expected -: subject findAnagrams candidates
 )
@@ -158,7 +158,7 @@ test_anagram_test_14  =: monad define
 
   subject    =. 'LISTEN'
   candidates =. 'LISTEN' ; 'Silent'
-  expected   =.  1 $ <'Silent'
+  expected   =.  ,<'Silent'
   assert expected -: subject findAnagrams candidates
 )
 

--- a/exercises/practice/collatz-conjecture/test.ijs
+++ b/exercises/practice/collatz-conjecture/test.ijs
@@ -13,9 +13,9 @@ test_collatz_conjecture_test_01  =: monad define
   Description@.1 ('zero steps for one')
   Order@.1 (1)
 
-  NB. number=. 1
-  NB. expected=. 0
-  assert 0 = steps 1
+  number   =. 1
+  expected =. 0
+  assert expected -: steps number
 )
 
 collatz_conjecture_test_02_ignore=: 1 NB. Change this value to 0 to run this test
@@ -23,9 +23,9 @@ test_collatz_conjecture_test_02  =: monad define
   Description@.1 ('divide if even')
   Order@.1 (2)
 
-  NB. number=. 16
-  NB. expected=. 4
-  assert 4 = steps 16
+  number   =. 16
+  expected =. 4
+  assert expected -: steps number
 )
 
 collatz_conjecture_test_03_ignore=: 1 NB. Change this value to 0 to run this test
@@ -33,9 +33,9 @@ test_collatz_conjecture_test_03  =: monad define
   Description@.1 ('even and odd steps')
   Order@.1 (3)
 
-  NB. number=. 12
-  NB. expected=. 9
-  assert 9 = steps 12
+  number   =. 12
+  expected =. 9
+  assert expected -: steps number
 )
 
 collatz_conjecture_test_04_ignore=: 1 NB. Change this value to 0 to run this test
@@ -43,9 +43,9 @@ test_collatz_conjecture_test_04  =: monad define
   Description@.1 ('large number of even and odd steps')
   Order@.1 (4)
 
-  NB. number=. 1000000
-  NB. expected=. 152
-  assert 152 = steps 1000000
+  number   =. 1000000
+  expected =. 152
+  assert expected -: steps number
 )
 
 NB. Error cases
@@ -57,10 +57,9 @@ test_collatz_conjecture_test_05  =: monad define
   Description@.1 ('zero is an error')
   Order@.1 (5)
 
-  NB. number=. 0
-  NB. expected=. 0 
-  NB. expected_error=. 'Only positive integers are allowed: domain'
-  assert 0 = steps 0
+  number   =. 0
+  expected =. 0 NB. error=. 'Only positive integers are allowed: domain'
+  assert expected -: steps number
 )
 
 collatz_conjecture_test_06_ignore=: 1 NB. Change this value to 0 to run this test
@@ -69,9 +68,8 @@ test_collatz_conjecture_test_06  =: monad define
   Description@.1 ('negative value is an error')
   Order@.1 (6)
 
-  NB. number=. _15
-  NB. expected=. 0 
-  NB. expected_error=. 'Only positive integers are allowed: domain'
-  assert 0 = steps _15
+  number   =. _15
+  expected =. 0  NB. error=. 'Only positive integers are allowed: domain'
+  assert expected -: steps number
 )
 

--- a/exercises/practice/difference-of-squares/test.ijs
+++ b/exercises/practice/difference-of-squares/test.ijs
@@ -14,9 +14,9 @@ test_square_of_sum_test_01  =: monad define
   Order@.1 (1)
   Task@.1 (1)
   
-  NB. number=. 1
-  NB. expected=. 1
-  assert 1 = square_of_sum 1
+  number   =. 1
+  expected =. 1
+  assert expected -: square_of_sum number
 )
 
 square_of_sum_test_02_ignore=: 1 NB. Change this value to 0 to run this test
@@ -25,9 +25,9 @@ test_square_of_sum_test_02  =: monad define
   Order@.1 (2)
   Task@.1 (1)
   
-  NB. number=. 5
-  NB. expected=. 225
-  assert 225 = square_of_sum 5
+  number   =. 5
+  expected =. 225
+  assert expected -: square_of_sum number
 )
 
 square_of_sum_test_03_ignore=: 1 NB. Change this value to 0 to run this test
@@ -36,9 +36,9 @@ test_square_of_sum_test_03  =: monad define
   Order@.1 (3)
   Task@.1 (1)
   
-  NB. number=. 100
-  NB. expected=. 25502500
-  assert 25502500 = square_of_sum 100
+  number   =. 100
+  expected =. 25502500
+  assert expected -: square_of_sum number
 )
 
 sum_of_square_test_01_ignore=: 1 NB. Change this value to 0 to run this test
@@ -47,9 +47,9 @@ test_sum_of_square_test_01  =: monad define
   Order@.1 (4)
   Task@.1 (2)
   
-  NB. number=. 1
-  NB. expected=. 1
-  assert 1 = sum_of_square 1
+  number   =. 1
+  expected =. 1
+  assert expected -: sum_of_square number
 )
 
 sum_of_square_test_02_ignore=: 1 NB. Change this value to 0 to run this test
@@ -58,9 +58,9 @@ test_sum_of_square_test_02  =: monad define
   Order@.1 (5)
   Task@.1 (2)
   
-  NB. number=. 5
-  NB. expected=. 55
-  assert 55 = sum_of_square 5
+  number   =. 5
+  expected =. 55
+  assert expected -: sum_of_square number
 )
 
 sum_of_square_test_03_ignore=: 1 NB. Change this value to 0 to run this test
@@ -69,9 +69,9 @@ test_sum_of_square_test_03  =: monad define
   Order@.1 (6)
   Task@.1 (2)
   
-  NB. number=. 100
-  NB. expected=. 338350
-  assert 338350 = sum_of_square 100
+  number   =. 100
+  expected =. 338350
+  assert expected -: sum_of_square number
 )
 
 difference_of_squares_test_01_ignore=: 1 NB. Change this value to 0 to run this test
@@ -80,9 +80,9 @@ test_difference_of_squares_test_01  =: monad define
   Order@.1 (7)
   Task@.1 (3)
   
-  NB. number=. 1
-  NB. expected=. 0
-  assert 0 = difference_of_squares 1
+  number   =. 1
+  expected =. 0
+  assert expected -: difference_of_squares number
 )
 
 difference_of_squares_test_02_ignore=: 1 NB. Change this value to 0 to run this test
@@ -91,9 +91,9 @@ test_difference_of_squares_test_02  =: monad define
   Order@.1 (8)
   Task@.1 (3)
   
-  NB. number=. 5
-  NB. expected=. 170
-  assert 170 = difference_of_squares 5
+  number   =. 5
+  expected =. 170
+  assert expected -: difference_of_squares number
 )
 
 difference_of_squares_test_03_ignore=: 1 NB. Change this value to 0 to run this test
@@ -102,7 +102,7 @@ test_difference_of_squares_test_03  =: monad define
   Order@.1 (9)
   Task@.1 (3)
   
-  NB. number=. 100
-  NB. expected=. 25164150
-  assert 25164150 = difference_of_squares 100
+  number   =. 100
+  expected =. 25164150
+  assert expected -: difference_of_squares number
 )

--- a/exercises/practice/dnd-character/test.ijs
+++ b/exercises/practice/dnd-character/test.ijs
@@ -14,9 +14,9 @@ test_dnd_character_test_01  =: monad define
   Order@.1 (1)
   Task@.1 (1)
 
-  NB. score=. 3
-  NB. expected=. _4
-  assert _4 -: modifier 3
+  score    =. 3
+  expected =. _4
+  assert expected -: modifier score
 )
 
 dnd_character_test_02_ignore=: 1 NB. Change this value to 0 to run this test
@@ -25,10 +25,9 @@ test_dnd_character_test_02  =: monad define
   Order@.1 (2)
   Task@.1 (1)
 
-
-  NB. score=. 4
-  NB. expected=. _3
-  assert _3 -: modifier 4
+  score    =. 4
+  expected =. _3
+  assert expected -: modifier score
 )
 
 dnd_character_test_03_ignore=: 1 NB. Change this value to 0 to run this test
@@ -37,9 +36,9 @@ test_dnd_character_test_03  =: monad define
   Order@.1 (3)
   Task@.1 (1)
 
-  NB. score=. 5
-  NB. expected=. _3
-  assert _3 -: modifier 5
+  score    =. 5
+  expected =. _3
+  assert expected -: modifier score
 )
 
 dnd_character_test_04_ignore=: 1 NB. Change this value to 0 to run this test
@@ -48,9 +47,9 @@ test_dnd_character_test_04  =: monad define
   Order@.1 (4)
   Task@.1 (1)
 
-  NB. score=. 6
-  NB. expected=. _2
-  assert _2 -: modifier 6
+  score    =. 6
+  expected =. _2
+  assert expected -: modifier score
 )
 
 dnd_character_test_05_ignore=: 1 NB. Change this value to 0 to run this test
@@ -59,9 +58,9 @@ test_dnd_character_test_05  =: monad define
   Order@.1 (5)
   Task@.1 (1)
 
-  NB. score=. 7
-  NB. expected=. _2
-  assert _2 -: modifier 7
+  score    =. 7
+  expected =. _2
+  assert expected -: modifier score
 )
 
 dnd_character_test_06_ignore=: 1 NB. Change this value to 0 to run this test
@@ -70,9 +69,9 @@ test_dnd_character_test_06  =: monad define
   Order@.1 (6)
   Task@.1 (1)
 
-  NB. score=. 8
-  NB. expected=. _1
-  assert _1 -: modifier 8
+  score    =. 8
+  expected =. _1
+  assert expected -: modifier score
 )
 
 dnd_character_test_07_ignore=: 1 NB. Change this value to 0 to run this test
@@ -81,9 +80,9 @@ test_dnd_character_test_07  =: monad define
   Order@.1 (7)
   Task@.1 (1)
 
-  NB. score=. 9
-  NB. expected=. _1
-  assert _1 -: modifier 9
+  score    =. 9
+  expected =. _1
+  assert expected -: modifier score
 )
 
 dnd_character_test_08_ignore=: 1 NB. Change this value to 0 to run this test
@@ -92,9 +91,9 @@ test_dnd_character_test_08  =: monad define
   Order@.1 (8)
   Task@.1 (1)
 
-  NB. score=. 10
-  NB. expected=. 0
-  assert 0 -: modifier 10
+  score    =. 10
+  expected =. 0
+  assert expected -: modifier score
 )
 
 dnd_character_test_09_ignore=: 1 NB. Change this value to 0 to run this test
@@ -103,9 +102,9 @@ test_dnd_character_test_09  =: monad define
   Order@.1 (9)
   Task@.1 (1)
 
-  NB. score=. 11
-  NB. expected=. 0
-  assert 0 -: modifier 11
+  score    =. 11
+  expected =. 0
+  assert expected -: modifier score
 )
 
 dnd_character_test_10_ignore=: 1 NB. Change this value to 0 to run this test
@@ -114,9 +113,9 @@ test_dnd_character_test_10  =: monad define
   Order@.1 (10)
   Task@.1 (1)
 
-  NB. score=. 12
-  NB. expected=. 1
-  assert 1 -: modifier 12
+  score    =. 12
+  expected =. 1
+  assert expected -: modifier score
 )
 
 dnd_character_test_11_ignore=: 1 NB. Change this value to 0 to run this test
@@ -125,9 +124,9 @@ test_dnd_character_test_11  =: monad define
   Order@.1 (11)
   Task@.1 (1)
 
-  NB. score=. 13
-  NB. expected=. 1
-  assert 1 -: modifier 13
+  score    =. 13
+  expected =. 1
+  assert expected -: modifier score
 )
 
 dnd_character_test_12_ignore=: 1 NB. Change this value to 0 to run this test
@@ -136,9 +135,9 @@ test_dnd_character_test_12  =: monad define
   Order@.1 (12)
   Task@.1 (1)
 
-  NB. score=. 14
-  NB. expected=. 2
-  assert 2 -: modifier 14
+  score    =. 14
+  expected =. 2
+  assert expected -: modifier score
 )
 
 dnd_character_test_13_ignore=: 1 NB. Change this value to 0 to run this test
@@ -147,9 +146,9 @@ test_dnd_character_test_13  =: monad define
   Order@.1 (13)
   Task@.1 (1)
 
-  NB. score=. 15
-  NB. expected=. 2
-  assert 2 -: modifier 15
+  score    =. 15
+  expected =. 2
+  assert expected -: modifier score
 )
 
 dnd_character_test_14_ignore=: 1 NB. Change this value to 0 to run this test
@@ -158,9 +157,9 @@ test_dnd_character_test_14  =: monad define
   Order@.1 (14)
   Task@.1 (1)
 
-  NB. score=. 16
-  NB. expected=. 3
-  assert 3 -: modifier 16
+  score    =. 16
+  expected =. 3
+  assert expected -: modifier score
 )
 
 dnd_character_test_15_ignore=: 1 NB. Change this value to 0 to run this test
@@ -169,9 +168,9 @@ test_dnd_character_test_15  =: monad define
   Order@.1 (15)
   Task@.1 (1)
 
-  NB. score=. 17
-  NB. expected=. 3
-  assert 3 -: modifier 17
+  score    =. 17
+  expected =. 3
+  assert expected -: modifier score
 )
 
 dnd_character_test_16_ignore=: 1 NB. Change this value to 0 to run this test
@@ -180,9 +179,9 @@ test_dnd_character_test_16  =: monad define
   Order@.1 (16)
   Task@.1 (1)
 
-  NB. score=. 18
-  NB. expected=. 4
-  assert 4 -: modifier 18
+  score    =. 18
+  expected =. 4
+  assert expected -: modifier score
 )
 
 dnd_character_test_17_ignore=: 1 NB. Change this value to 0 to run this test
@@ -192,8 +191,7 @@ test_dnd_character_test_17  =: monad define
   Task@.1 (2)
   ability_within_range=. 3 {{ >:&u *. <:&v }} 18
 
-  NB. input=. ''
-  NB. expected=. 1 = (>:&3 *. <:&18)
+  input=. ''
   assert ability_within_range ability ''
 )
 
@@ -205,9 +203,9 @@ test_dnd_character_test_18  =: monad define
   Task@.1 (3)
   ability_within_range=. 3 {{ >:&u *. <:&v }} 18
   
-  NB. input=. ''
-  NB. expected=. 1 = *./
-  c =. character ''
+  input=. ''
+  c    =. character ''
+
   assert ability_within_range STRENGTH
   assert ability_within_range DEXTERITY
   assert ability_within_range CONSTITUTION
@@ -222,9 +220,9 @@ test_dnd_character_test_19  =: monad define
   Order@.1 (19)
   Task@.1 (4)
 
-  NB. input=. ''
-  NB. expected=. 1 = *./
-  c =. character ''
+  input=. ''
+  c    =. character ''
+
   assert STRENGTH = STRENGTH
   assert DEXTERITY = DEXTERITY
   assert CONSTITUTION = CONSTITUTION

--- a/exercises/practice/hamming/test.ijs
+++ b/exercises/practice/hamming/test.ijs
@@ -13,10 +13,10 @@ test_hamming_test_01  =: monad define
   Description@.1 ('empty strands')
   Order@.1 (1)
 
-  NB. strand1=. '' 
-  NB. strand2=. '' 
-  NB. expected=. 0
-  assert 0 = '' distance ''
+  strand1  =. '' 
+  strand2  =. '' 
+  expected =. 0
+  assert expected -: strand1 distance strand2
 )
 
 hamming_test_02_ignore=: 1 NB. Change this value to 0 to run this test
@@ -24,10 +24,10 @@ test_hamming_test_02  =: monad define
   Description@.1 ('single letter identical strands')
   Order@.1 (2)
 
-  NB. strand1=. 'A' 
-  NB. strand2=. 'A' 
-  NB. expected=. 0
-  assert 0 = 'A' distance 'A'
+  strand1  =. 'A' 
+  strand2  =. 'A' 
+  expected =. 0
+  assert expected -: strand1 distance strand2
 )
 
 hamming_test_03_ignore=: 1 NB. Change this value to 0 to run this test
@@ -35,10 +35,10 @@ test_hamming_test_03  =: monad define
   Description@.1 ('single letter different strands')
   Order@.1 (3)
 
-  NB. strand1=. 'G' 
-  NB. strand2=. 'T' 
-  NB. expected=. 1
-  assert 1 = 'G' distance 'T'
+  strand1  =. 'G' 
+  strand2  =. 'T' 
+  expected =. 1
+  assert expected -: strand1 distance strand2
 )
 
 hamming_test_04_ignore=: 1 NB. Change this value to 0 to run this test
@@ -46,10 +46,10 @@ test_hamming_test_04  =: monad define
   Description@.1 ('long identical strands')
   Order@.1 (4)
 
-  NB. strand1=. 'GGACTGAAATCTG' 
-  NB. strand2=. 'GGACTGAAATCTG' 
-  NB. expected=. 0
-  assert 0 = 'GGACTGAAATCTG' distance 'GGACTGAAATCTG'
+  strand1  =. 'GGACTGAAATCTG' 
+  strand2  =. 'GGACTGAAATCTG' 
+  expected =. 0
+  assert expected -: strand1 distance strand2
 )
 
 hamming_test_05_ignore=: 1 NB. Change this value to 0 to run this test
@@ -57,10 +57,10 @@ test_hamming_test_05  =: monad define
   Description@.1 ('long different strands')
   Order@.1 (5)
 
-  NB. strand1=. 'GGACGGATTCTG' 
-  NB. strand2=. 'AGGACGGATTCT' 
-  NB. expected=. 9
-  assert 9 = 'GGACGGATTCTG' distance 'AGGACGGATTCT' 
+  strand1  =. 'GGACGGATTCTG' 
+  strand2  =. 'AGGACGGATTCT' 
+  expected =. 9
+  assert expected -: strand1 distance strand2 
 )
 
 hamming_test_06_ignore=: 1 NB. Change this value to 0 to run this test
@@ -69,10 +69,10 @@ test_hamming_test_06  =: monad define
   Description@.1 ('disallow first strand longer')
   Order@.1 (6)
 
-  NB. strand1=. 'AATG'
-  NB. strand2=. 'AAA'
-  NB. expected=. 'length error'
-  assert 'AATG' distance 'AAA'
+  strand1  =. 'AATG'
+  strand2  =. 'AAA'
+  expected =. 'length error'
+  assert strand1 distance strand2
 )
 
 hamming_test_07_ignore=: 1 NB. Change this value to 0 to run this test
@@ -81,10 +81,10 @@ test_hamming_test_07  =: monad define
   Description@.1 ('disallow second strand longer')
   Order@.1 (7)
 
-  NB. strand1=. 'ATA'
-  NB. strand2=. 'AGTG'
-  NB. expected=. 'length error'
-  assert 'ATA' distance 'AGTG'
+  strand1  =. 'ATA'
+  strand2  =. 'AGTG'
+  expected =. 'length error'
+  assert strand1 distance strand2
 )
 
 hamming_test_08_ignore=: 1 NB. Change this value to 0 to run this test
@@ -93,10 +93,10 @@ test_hamming_test_08  =: monad define
   Description@.1 ('disallow left empty strand')
   Order@.1 (8)
 
-  NB. strand1=. 0$''
-  NB. strand2=. 1$'G'
-  NB. expected=. 'length error'
-  assert (0$'') distance (1$'G')
+  strand1  =. ''
+  strand2  =. ,'G'
+  expected =. 'length error'
+  assert strand1 distance strand2
 )
 
 hamming_test_09_ignore=: 1 NB. Change this value to 0 to run this test
@@ -105,9 +105,9 @@ test_hamming_test_09  =: monad define
   Description@.1 ('disallow empty second strand')
   Order@.1 (9)
 
-  NB. strand1=. 1$'G'
-  NB. strand2=. 0$''
-  NB. expected=. 'length error'
-  assert (1$'G') distance (0$'')
+  strand1  =. ,'G'
+  strand2  =. ''
+  expected =. 'length error'
+  assert strand1 distance strand2
 )
 

--- a/exercises/practice/leap/test.ijs
+++ b/exercises/practice/leap/test.ijs
@@ -13,9 +13,9 @@ test_leap_test_01  =: monad define
   Description@.1 ('year not divisible by 4 in common year')
   Order@.1 (1)
   
-  NB. year=.2015
-  NB. expected=. 0
-  assert 0 = leapYear 2015
+  year    =. 2015
+  expected=. 0
+  assert expected = leapYear year
 )
 
 leap_test_02_ignore=: 1 NB. Change this value to 0 to run this test
@@ -23,9 +23,9 @@ test_leap_test_02  =: monad define
   Description@.1 ('year divisible by 2, not divisible by 4 in common year')
   Order@.1 (2)
 
-  NB. year=.1970
-  NB. expected=. 0
-  assert 0 = leapYear 1970
+  year    =. 1970
+  expected=. 0
+  assert expected = leapYear year
 )
 
 leap_test_03_ignore=: 1 NB. Change this value to 0 to run this test
@@ -33,9 +33,9 @@ test_leap_test_03  =: monad define
   Description@.1 ('year divisible by 4, not divisible by 100 in leap year')
   Order@.1 (3)
 
-  NB. year=.1996
-  NB. Expecrted=: 1
-  assert 1 = leapYear 1996
+  year    =. 1996
+  expected=.  1
+  assert expected = leapYear year
 )
 
 leap_test_04_ignore=: 1 NB. Change this value to 0 to run this test
@@ -43,9 +43,9 @@ test_leap_test_04  =: monad define
   Description@.1 ('year divisible by 4 and 5 is still a leap year')
   Order@.1 (4)
 
-  NB. year=.1960
-  NB. expected=. 1
-  assert 1 = leapYear 1960
+  year    =. 1960
+  expected=. 1
+  assert expected = leapYear year
 )
 
 leap_test_05_ignore=: 1 NB. Change this value to 0 to run this test
@@ -53,9 +53,9 @@ test_leap_test_05  =: monad define
   Description@.1 ('year divisible by 100, not divisible by 400 in common year')
   Order@.1 (5)
 
-  NB. year=.2100
-  NB. expected=. 0
-  assert 0 = leapYear 2100
+  year    =. 2100
+  expected=. 0
+  assert expected = leapYear year
 )
 
 leap_test_06_ignore=: 1 NB. Change this value to 0 to run this test
@@ -63,9 +63,9 @@ test_leap_test_06  =: monad define
   Description@.1 ('year divisible by 100 but not by 3 is still not a leap year')
   Order@.1 (6)
 
-  NB. year=.1900
-  NB. expected=. 0
-  assert 0 = leapYear 1900
+  year    =. 1900
+  expected=. 0
+  assert expected = leapYear year
 )
 
 leap_test_07_ignore=: 1 NB. Change this value to 0 to run this test
@@ -73,9 +73,9 @@ test_leap_test_07  =: monad define
   Description@.1 ('year divisible by 400 is leap year')
   Order@.1 (7)
   
-  NB. year=.2000
-  NB. expected=. 1
-  assert 1 = leapYear 2000
+  year    =. 2000
+  expected=. 1
+  assert expected = leapYear year
 )
 
 leap_test_08_ignore=: 1 NB. Change this value to 0 to run this test
@@ -83,9 +83,9 @@ test_leap_test_08  =: monad define
   Description@.1 ('year divisible by 400 but not by 125 is still a leap year')
   Order@.1 (8)
 
-  NB. year=.2400
-  NB. expected=. 1
-  assert 1 = leapYear 2400
+  year    =. 2400
+  expected=. 1
+  assert expected = leapYear year
 )
 
 leap_test_09_ignore=: 1 NB. Change this value to 0 to run this test
@@ -93,7 +93,7 @@ test_leap_test_09  =: monad define
   Description@.1 ('year divisible by 200, not divisible by 400 in common year')
   Order@.1 (9)
 
-  NB. year=.1800
-  NB. expected=. 0
-  assert 0 = leapYear 1800
+  year    =. 1800
+  expected=. 0
+  assert expected = leapYear year
 )

--- a/exercises/practice/pascals-triangle/test.ijs
+++ b/exercises/practice/pascals-triangle/test.ijs
@@ -54,7 +54,7 @@ test_pascals_triangle_test_05  =: monad define
   Order@.1 (5)
 
   NB. count=: 4
-  expected=. 1 ; 1 1 ; 1 2 1 ; 1 3 3 1
+  expected=. > 1 ; 1 1 ; 1 2 1 ; 1 3 3 1
   assert expected -: > pascal 4
 )
 

--- a/exercises/practice/raindrops/test.ijs
+++ b/exercises/practice/raindrops/test.ijs
@@ -13,9 +13,9 @@ test_raindrops_test_01  =: monad define
   Description@.1 ('the sound for 1 is 1')
   Order@.1 (1)
 
-  NB. number=. 1
-  NB. expected=. '1'
-  assert '1' = convert 1
+  number  =. 1
+  expected=. ,'1'
+  assert expected -: convert number
 )
 
 raindrops_test_02_ignore=: 1 NB. Change this value to 0 to run this test
@@ -23,9 +23,9 @@ test_raindrops_test_02  =: monad define
   Description@.1 ('the sound for 3 is Pling')
   Order@.1 (2)
 
-  NB. number=. 3
-  NB. expected=. 'Pling'
-  assert 'Pling' = convert 3
+  number  =. 3
+  expected=. 'Pling'
+  assert expected -: convert number
 )
 
 raindrops_test_03_ignore=: 1 NB. Change this value to 0 to run this test
@@ -33,9 +33,9 @@ test_raindrops_test_03  =: monad define
   Description@.1 ('the sound for 5 is Plang')
   Order@.1 (3)
 
-  NB. number=. 5
-  NB. expected=. 'Plang'
-  assert 'Plang' = convert 5
+  number  =. 5
+  expected=. 'Plang'
+  assert expected -: convert number
 )
 
 raindrops_test_04_ignore=: 1 NB. Change this value to 0 to run this test
@@ -43,9 +43,9 @@ test_raindrops_test_04  =: monad define
   Description@.1 ('the sound for 7 is Plong')
   Order@.1 (4)
 
-  NB. number=. 7
-  NB. expected=. 'Plong'
-  assert 'Plong' = convert 7
+  number  =. 7
+  expected=. 'Plong'
+  assert expected -: convert number
 )
 
 raindrops_test_05_ignore=: 1 NB. Change this value to 0 to run this test
@@ -53,9 +53,9 @@ test_raindrops_test_05  =: monad define
   Description@.1 ('the sound for 6 is Pling as it has a factor 3')
   Order@.1 (5)
 
-  NB. number=. 6
-  NB. expected=. 'Pling'
-  assert 'Pling' = convert 6
+  number  =. 6
+  expected=. 'Pling'
+  assert expected -: convert number
 )
 
 raindrops_test_06_ignore=: 1 NB. Change this value to 0 to run this test
@@ -63,9 +63,9 @@ test_raindrops_test_06  =: monad define
   Description@.1 ('2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base')
   Order@.1 (6)
 
-  NB. number=. 8
-  NB. expected=. '8'
-  assert '8' = convert 8
+  number  =. 8
+  expected=. ,'8'
+  assert expected -: convert number
 )
 
 raindrops_test_07_ignore=: 1 NB. Change this value to 0 to run this test
@@ -73,9 +73,9 @@ test_raindrops_test_07  =: monad define
   Description@.1 ('the sound for 9 is Pling as it has a factor 3')
   Order@.1 (7)
 
-  NB. number=. 9
-  NB. expected=. 'Pling'
-  assert 'Pling' = convert 9
+  number  =. 9
+  expected=. 'Pling'
+  assert expected -: convert number
 )
 
 raindrops_test_08_ignore=: 1 NB. Change this value to 0 to run this test
@@ -83,9 +83,9 @@ test_raindrops_test_08  =: monad define
   Description@.1 ('the sound for 10 is Plang as it has a factor 5')
   Order@.1 (8)
 
-  NB. number=. 10
-  NB. expected=. 'Plang'
-  assert 'Plang' = convert 10
+  number  =. 10
+  expected=. 'Plang'
+  assert expected -: convert number
 )
 
 raindrops_test_09_ignore=: 1 NB. Change this value to 0 to run this test
@@ -93,9 +93,9 @@ test_raindrops_test_09  =: monad define
   Description@.1 ('the sound for 14 is Plong as it has a factor of 7')
   Order@.1 (9)
 
-  NB. number=. 14
-  NB. expected=. 'Plong'
-  assert 'Plong' = convert 14
+  number  =. 14
+  expected=. 'Plong'
+  assert expected -: convert number
 )
 
 raindrops_test_10_ignore=: 1 NB. Change this value to 0 to run this test
@@ -103,9 +103,9 @@ test_raindrops_test_10  =: monad define
   Description@.1 ('the sound for 15 is PlingPlang as it has factors 3 and 5')
   Order@.1 (10)
 
-  NB. number=. 15
-  NB. expected=. 'PlingPlang'
-  assert 'PlingPlang' = convert 15
+  number  =. 15
+  expected=. 'PlingPlang'
+  assert expected -: convert number
 )
 
 raindrops_test_11_ignore=: 1 NB. Change this value to 0 to run this test
@@ -113,9 +113,9 @@ test_raindrops_test_11  =: monad define
   Description@.1 ('the sound for 21 is PlingPlong as it has factors 3 and 7')
   Order@.1 (11)
 
-  NB. number=. 21
-  NB. expected=. 'PlingPlong'
-  assert 'PlingPlong' = convert 21
+  number  =. 21
+  expected=. 'PlingPlong'
+  assert expected -: convert number
 )
 
 raindrops_test_12_ignore=: 1 NB. Change this value to 0 to run this test
@@ -123,9 +123,9 @@ test_raindrops_test_12  =: monad define
   Description@.1 ('the sound for 25 is Plang as it has a factor 5')
   Order@.1 (12)
 
-  NB. number=. 25
-  NB. expected=. 'Plang'
-  assert 'Plang' = convert 25
+  number  =. 25
+  expected=. 'Plang'
+  assert expected -: convert number
 )
 
 raindrops_test_13_ignore=: 1 NB. Change this value to 0 to run this test
@@ -133,9 +133,9 @@ test_raindrops_test_13  =: monad define
   Description@.1 ('the sound for 27 is Pling as it has a factor 3')
   Order@.1 (13)
 
-  NB. number=. 27
-  NB. expected=. 'Pling'
-  assert 'Pling' = convert 27
+  number  =. 27
+  expected=. 'Pling'
+  assert expected -: convert number
 )
 
 raindrops_test_14_ignore=: 1 NB. Change this value to 0 to run this test
@@ -143,9 +143,9 @@ test_raindrops_test_14  =: monad define
   Description@.1 ('the sound for 35 is PlangPlong as it has factors 5 and 7')
   Order@.1 (14)
 
-  NB. number=. 35
-  NB. expected=. 'PlangPlong'
-  assert 'PlangPlong' = convert 35
+  number  =. 35
+  expected=. 'PlangPlong'
+  assert expected -: convert number
 )
 
 raindrops_test_15_ignore=: 1 NB. Change this value to 0 to run this test
@@ -153,9 +153,9 @@ test_raindrops_test_15  =: monad define
   Description@.1 ('the sound for 49 is Plong as it has a factor 7')
   Order@.1 (15)
 
-  NB. number=. 49
-  NB. expected=. 'Plong'
-  assert 'Plong' = convert 49
+  number  =. 49
+  expected=. 'Plong'
+  assert expected -: convert number
 )
 
 raindrops_test_16_ignore=: 1 NB. Change this value to 0 to run this test
@@ -163,9 +163,9 @@ test_raindrops_test_16  =: monad define
   Description@.1 ('the sound for 52 is 52')
   Order@.1 (16)
 
-  NB. number=. 52
-  NB. expected=. '52'
-  assert '52' = convert 52
+  number  =. 52
+  expected=. '52'
+  assert expected -: convert number
 )
 
 raindrops_test_17_ignore=: 1 NB. Change this value to 0 to run this test
@@ -173,9 +173,9 @@ test_raindrops_test_17  =: monad define
   Description@.1 ('the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7')
   Order@.1 (17)
 
-  NB. number=. 105
-  NB. expected=. 'PlingPlangPlong'
-  assert 'PlingPlangPlong' = convert 105
+  number  =. 105
+  expected=. 'PlingPlangPlong'
+  assert expected -: convert number
 )
 
 raindrops_test_18_ignore=: 1 NB. Change this value to 0 to run this test
@@ -183,7 +183,7 @@ test_raindrops_test_18  =: monad define
   Description@.1 ('the sound for 3125 is Plang as it has a factor 5')
   Order@.1 (18)
 
-  NB. number=. 3125
-  NB. expected=. 'Plang'
-  assert 'Plang' = convert 3125
+  number  =. 3125
+  expected=. 'Plang'
+  assert expected -: convert number
 )

--- a/exercises/practice/sum-of-multiples/test.ijs
+++ b/exercises/practice/sum-of-multiples/test.ijs
@@ -13,10 +13,10 @@ test_sum_of_multiples_test_01  =: monad define
   Description@.1 ('no multiples within limit')
   Order@.1 (1)
 
-  NB. factors=. 3 5
-  NB. limit=. 1
-  NB. expected=. 0
-  assert 0 = 3 5 sum 1
+  factors =. 3 5
+  limit   =. 1
+  expected=. 0
+  assert expected -: factors sum limit
 )
 
 sum_of_multiples_test_02_ignore=: 1 NB. Change this value to 0 to run this test
@@ -24,10 +24,10 @@ test_sum_of_multiples_test_02  =: monad define
   Description@.1 ('one factor has multiples within limit')
   Order@.1 (2)
 
-  NB. factors=. 3 5
-  NB. limit=. 4
-  NB. expected=. 3
-  assert 3 = 3 5  sum 4
+  factors =. 3 5
+  limit   =. 4
+  expected=. 3
+  assert expected -: factors sum limit
 )
 
 sum_of_multiples_test_03_ignore=: 1 NB. Change this value to 0 to run this test
@@ -35,10 +35,10 @@ test_sum_of_multiples_test_03  =: monad define
   Description@.1 ('more than one multiple within limit')
   Order@.1 (3)
 
-  NB. factors=. 1$3
-  NB. limit=. 7
-  NB. expected=. 9
-  assert 9 = (1$3) sum 7
+  factors =. 1$3
+  limit   =. 7
+  expected=. 9
+  assert expected -: factors sum limit
 )
 
 sum_of_multiples_test_04_ignore=: 1 NB. Change this value to 0 to run this test
@@ -46,10 +46,10 @@ test_sum_of_multiples_test_04  =: monad define
   Description@.1 ('more than one factor with multiples within limit')
   Order@.1 (4)
 
-  NB. factors=. 3 5
-  NB. limit=. 10
-  NB. expected=. 23
-  assert 23 = 3 5 sum 10
+  factors =. 3 5
+  limit   =. 10
+  expected=. 23
+  assert expected -: factors sum limit
 )
 
 sum_of_multiples_test_05_ignore=: 1 NB. Change this value to 0 to run this test
@@ -57,10 +57,10 @@ test_sum_of_multiples_test_05  =: monad define
   Description@.1 ('each multiple is only counted once')
   Order@.1 (5)
 
-  NB. factors=. 3 5
-  NB. limit=. 100
-  NB. expected=. 2318
-  assert 2318 = 3 5 sum 100
+  factors =. 3 5
+  limit   =. 100
+  expected=. 2318
+  assert expected -: factors sum limit
 )
 
 sum_of_multiples_test_06_ignore=: 1 NB. Change this value to 0 to run this test
@@ -68,10 +68,10 @@ test_sum_of_multiples_test_06  =: monad define
   Description@.1 ('a much larger limit')
   Order@.1 (6)
 
-  NB. factors=. 3 5
-  NB. limit=. 1000
-  NB. expected=. 233168
-  assert 233168 = 3 5 sum 100
+  factors =. 3 5
+  limit   =. 100
+  expected=. 2318
+  assert expected -: factors sum limit
 )
 
 sum_of_multiples_test_07_ignore=: 1 NB. Change this value to 0 to run this test
@@ -79,10 +79,10 @@ test_sum_of_multiples_test_07  =: monad define
   Description@.1 ('three factors')
   Order@.1 (7)
 
-  NB. factors=. 7 13 17
-  NB. limit=. 20
-  NB. expected=. 51
-  assert 51 = 7 13 17 sum 20
+  factors =. 7 13 17
+  limit   =. 20
+  expected=. 51
+  assert expected -: factors sum limit
 )
 
 sum_of_multiples_test_08_ignore=: 1 NB. Change this value to 0 to run this test
@@ -90,10 +90,10 @@ test_sum_of_multiples_test_08  =: monad define
   Description@.1 ('factors not relatively prime')
   Order@.1 (8)
 
-  NB. factors=. 4 6
-  NB. limit=. 15
-  NB. expected=. 30
-  assert 30 = (1$15) sum 30
+  factors =. 4 6
+  limit   =. 15
+  expected=. 30
+  assert expected -: factors sum limit
 )
 
 sum_of_multiples_test_09_ignore=: 1 NB. Change this value to 0 to run this test
@@ -101,10 +101,10 @@ test_sum_of_multiples_test_09  =: monad define
   Description@.1 ('some pairs of factors relatively prime and some not')
   Order@.1 (9)
 
-  NB. factors=. 5 6 8
-  NB. limit=. 150
-  NB. expected=. 4419
-  assert 4419 = 5 6 8 sum 150
+  factors =. 5 6 8
+  limit   =. 150
+  expected=. 4419
+  assert expected -: factors sum limit
 )
 
 sum_of_multiples_test_10_ignore=: 1 NB. Change this value to 0 to run this test
@@ -112,10 +112,10 @@ test_sum_of_multiples_test_10  =: monad define
   Description@.1 ('one factor is a multiple of another')
   Order@.1 (10)
 
-  NB. factors=. 5 25
-  NB. limit=. 51
-  NB. expected=. 275
-  assert 275 = 5 25 sum 275
+  factors =. 5 25
+  limit   =. 51
+  expected=. 275
+  assert expected -: factors sum limit
 )
 
 sum_of_multiples_test_11_ignore=: 1 NB. Change this value to 0 to run this test
@@ -123,10 +123,10 @@ test_sum_of_multiples_test_11  =: monad define
   Description@.1 ('much larger factors')
   Order@.1 (11)
 
-  NB. factors=. 43 47
-  NB. limit=. 10000
-  NB. expected=. 2203160
-  assert 2203160 =  43 47 sum 10000
+  factors =. 43 47
+  limit   =. 10000
+  expected=. 2203160
+  assert expected -: factors sum limit
 )
 
 sum_of_multiples_test_12_ignore=: 1 NB. Change this value to 0 to run this test
@@ -134,10 +134,10 @@ test_sum_of_multiples_test_12  =: monad define
   Description@.1 ('all numbers are multiples of 1')
   Order@.1 (12)
 
-  NB. factors=. 1$1
-  NB. limit=. 100
-  NB. expected=. 4950
-  assert 4950 = (1$1) sum 100
+  factors =. 1$1
+  limit   =. 100
+  expected=. 4950
+  assert expected -: factors sum limit
 )
 
 sum_of_multiples_test_13_ignore=: 1 NB. Change this value to 0 to run this test
@@ -145,10 +145,10 @@ test_sum_of_multiples_test_13  =: monad define
   Description@.1 ('no factors means an empty sum')
   Order@.1 (13)
 
-  NB. factors=. (1$'')
-  NB. limit=. 10000
-  NB. expected=. 0
-  assert 0 = (1$'') sum 10000
+  factors =. ''
+  limit   =. 10000
+  expected=. 0
+  assert expected -: factors sum limit
 )
 
 sum_of_multiples_test_14_ignore=: 1 NB. Change this value to 0 to run this test
@@ -156,10 +156,10 @@ test_sum_of_multiples_test_14  =: monad define
   Description@.1 ('the only multiple of 0 is 0')
   Order@.1 (14)
 
-  NB. factors=. 1$0
-  NB. limit=. 1
-  NB. expected=. 0
-  assert 0 = (1$0) sum 1
+  factors =. 1$0
+  limit   =. 1
+  expected=. 0
+  assert expected -: factors sum limit
 )
 
 sum_of_multiples_test_15_ignore=: 1 NB. Change this value to 0 to run this test
@@ -167,10 +167,10 @@ test_sum_of_multiples_test_15  =: monad define
   Description@.1 ('the factor 0 does not affect the sum of multiples of other factors')
   Order@.1 (15)
 
-  NB. factors=. 3 0
-  NB. limit=. 4
-  NB. expected=. 3
-  assert 3 = 3 0 sum 4
+  factors =. 3 0
+  limit   =. 4
+  expected=. 3
+  assert expected -: factors sum limit
 )
 
 sum_of_multiples_test_16_ignore=: 1 NB. Change this value to 0 to run this test
@@ -178,9 +178,9 @@ test_sum_of_multiples_test_16  =: monad define
   Description@.1 ('solutions using include-exclude must extend to cardinality greater than 3')
   Order@.1 (16)
 
-  NB. factors=. 2 3 5 7 11
-  NB. limit=. 10000
-  NB. expected=. 39614537
-  assert 39614537 = 2 3 5 7 11 sum 10000
+  factors =. 2 3 5 7 11
+  limit   =. 10000
+  expected=. 39614537
+  assert expected -: factors sum limit
 )
 


### PR DESCRIPTION

- Add files to the github action for testing
- Correct tests behaviour when an atom is expected  and the solution returns `empty`

OBS.:
When the ecpected value of a test is an atom and the soultion produces `empty` comparisons done using the `=` verb will produce an empty shape. This causes assertions to always return true for the specified test. 
To address this issue, we have implemented the following solutions:

1. Replacing the Comparison Verb with -:: Instead of using =, we now use -: to compare atoms against empty results. This ensures that the assertion behaves as expected even when the result is empty.
1. Turning the Expected Value into a List Containing a Single Atom: In cases where the expected value is an atom, we wrap it in a list. This prevents the assertion from always evaluating to true when the solution returns an empty result.

The choice of which solution to apply was made on a case-by-case basis, considering the specific context of the exercise.