### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/all-your-base/.docs/instructions.append.md
+++ b/exercises/practice/all-your-base/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Additional Information
 
 ### Example Input

--- a/exercises/practice/all-your-base/.docs/instructions.append.md
+++ b/exercises/practice/all-your-base/.docs/instructions.append.md
@@ -1,8 +1,6 @@
 # Instructions append
 
-## Additional Information
-
-### Example Input
+## Example Input
 
 ```j
   INPUTS=: 2 ; 1 0 0 1 0 1 ; 10
@@ -14,11 +12,11 @@ This means that your inputs are:
   1{INPUTS NB. is the digits.
   2{INPUTS NB. is the output base.
 ```
-### Handling Invalid Inputs
+## Handling Invalid Inputs
 
 If any of the input values is invalid, your verb should return either an `empty`(e.g., `0$0` or `''`).
 
-#### Examples
+### Examples
 
 - If the _input base_ is smaller than 2:
     ```j

--- a/exercises/practice/allergies/.docs/instructions.append.md
+++ b/exercises/practice/allergies/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Notes
 
 You need to define two verbs called `allergic_to` and `list`

--- a/exercises/practice/allergies/.docs/instructions.append.md
+++ b/exercises/practice/allergies/.docs/instructions.append.md
@@ -1,10 +1,11 @@
 # Instructions append
 
-## Notes
+## Track specific instructions
 
-You need to define two verbs called `allergic_to` and `list`
+You need to define two verbs called `allergic_to` and `list`.
 
-### Inputs
+## Inputs
+
 1. `allergic_to` verb is **dyad** where:
 
     - **Left Argument**: is a string containing the allergen name.
@@ -20,7 +21,9 @@ Your verbs will be called with these arguments like so:
   'cats' allergic_to 255
   list 5
 ```
-### Outputs
+
+## Outputs
+
 The output of `allergic_to` verb is a **boolean**
 
 The output of `list` is a **list of boxes**

--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Additional Information
 
 ### Input

--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,8 +1,6 @@
 # Instructions append
 
-## Additional Information
-
-### Input
+# Input
 
 The input for this exercise are:
 
@@ -18,6 +16,6 @@ Your verb will be called like this:
   subject findAnagrams candidates
 ```
 
-### Output
+## Output
 
 Your verb should return a _list_ of boxes containig the strings that are anagrams of the target. If there are no anagrams, the result should be `empty`.

--- a/exercises/practice/kindergarten-garden/.docs/instructions.append.md
+++ b/exercises/practice/kindergarten-garden/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-## Notes
+## Track specific instructions
 
 Here's what you need to know about the input format:
 

--- a/exercises/practice/kindergarten-garden/.docs/instructions.append.md
+++ b/exercises/practice/kindergarten-garden/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Notes
 
 Here's what you need to know about the input format:

--- a/exercises/practice/pascals-triangle/.docs/instructions.append.md
+++ b/exercises/practice/pascals-triangle/.docs/instructions.append.md
@@ -1,11 +1,14 @@
 # Instructions append
 
 ## Output
+
 In this exercise, you will implement a verb that generates Pascal’s Triangle up to a given number of rows. The output from your verb can be formatted in one of two ways:
 
   1. As an array of boxed lists, where each list represents a row in Pascal’s Triangle.
   1. As a table, where the numbers are aligned to the right, and zeros are used to fill empty spaces on the left.
+
 ### Example output
+
 Here are two valid outputs for `pascal 3`:
 
   - As an array of boxed lists:

--- a/exercises/practice/pascals-triangle/.docs/instructions.append.md
+++ b/exercises/practice/pascals-triangle/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Output
 In this exercise, you will implement a verb that generates Pascal’s Triangle up to a given number of rows. The output from your verb can be formatted in one of two ways:
 

--- a/exercises/practice/robot-simulator/.docs/instructions.append.md
+++ b/exercises/practice/robot-simulator/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-## Notes
+## Track specific instructions
 
 For this exercise you need to define a **locale** named `robot` that defines the **nouns** `position` and `direction` and a **verb** `move`.
 

--- a/exercises/practice/robot-simulator/.docs/instructions.append.md
+++ b/exercises/practice/robot-simulator/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Notes
 
 For this exercise you need to define a **locale** named `robot` that defines the **nouns** `position` and `direction` and a **verb** `move`.

--- a/exercises/practice/space-age/.docs/instructions.append.md
+++ b/exercises/practice/space-age/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-## Notes
+## Track specific instructions
 
 Here's what you need to know about the input format:
 

--- a/exercises/practice/space-age/.docs/instructions.append.md
+++ b/exercises/practice/space-age/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Notes
 
 Here's what you need to know about the input format:

--- a/exercises/practice/sum-of-multiples/.docs/instructions.append.md
+++ b/exercises/practice/sum-of-multiples/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-## Notes
+## Track specific instructions
 
 For this exercise, your verb will receive two arguments:
 

--- a/exercises/practice/sum-of-multiples/.docs/instructions.append.md
+++ b/exercises/practice/sum-of-multiples/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Notes
 
 For this exercise, your verb will receive two arguments:

--- a/exercises/practice/yacht/.docs/instructions.append.md
+++ b/exercises/practice/yacht/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Notes
 
 In the "Yacht" exercise, you will create a verb that calculates the score for a single throw of five dice in the game Yacht, based on the chosen category.

--- a/exercises/practice/yacht/.docs/instructions.append.md
+++ b/exercises/practice/yacht/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-## Notes
+## Track specific instructions
 
 In the "Yacht" exercise, you will create a verb that calculates the score for a single throw of five dice in the game Yacht, based on the chosen category.
 


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.